### PR TITLE
Improvement/choose config branch from pipeline params

### DIFF
--- a/src/com/duvalhub/initializeworkdir/InitializeWorkdirIn.groovy
+++ b/src/com/duvalhub/initializeworkdir/InitializeWorkdirIn.groovy
@@ -12,6 +12,8 @@ class InitializeWorkdirIn extends BaseObject {
     GitRepo pipelineGitRepo
     Boolean clonePipelineRepo = true
 
+    String configGitBranch
+
     InitializeWorkdirIn() {
         this.pipelineGitRepo = new GitRepo("duvalhub", "continuous-deployment-shared-library")
         this.pipelineWorkdir = "jenkins-workdir"

--- a/vars/initializeWorkdir.groovy
+++ b/vars/initializeWorkdir.groovy
@@ -10,7 +10,7 @@ def call(InitializeWorkdirIn params = new InitializeWorkdirIn()) {
     // Download Shared Library
     initializeSharedLibrary(params)
 
-    def pipelineBranch = params.configGitBranch ?: SharedLibrary.getVersion(env) ?: "master"
+    def pipelineBranch = params?.configGitBranch ?: SharedLibrary.getVersion(env) ?: "master"
     GitRepo appGitRepo = params.getAppGitRepo()
 
     if (!appGitRepo) {

--- a/vars/initializeWorkdir.groovy
+++ b/vars/initializeWorkdir.groovy
@@ -11,6 +11,17 @@ def call(InitializeWorkdirIn params = new InitializeWorkdirIn()) {
     initializeSharedLibrary(params)
 
     def pipelineBranch = params?.configGitBranch ?: SharedLibrary.getVersion(env) ?: "master"
+    if(params?.configGitBranch) {
+        echo "hello"
+    } else if (SharedLibrary.getVersion(env)) {
+        echo "tourlou"
+    } else {
+        echo "hioh"
+    }
+    echo "${params?.configGitBranch}"
+    echo "${SharedLibrary.getVersion(env)}"
+    echo "${pipelineBranch}"
+
     GitRepo appGitRepo = params.getAppGitRepo()
 
     if (!appGitRepo) {

--- a/vars/initializeWorkdir.groovy
+++ b/vars/initializeWorkdir.groovy
@@ -10,7 +10,7 @@ def call(InitializeWorkdirIn params = new InitializeWorkdirIn()) {
     // Download Shared Library
     initializeSharedLibrary(params)
 
-    def pipelineBranch = SharedLibrary.getVersion(env) ?: "master"
+    def pipelineBranch = params.configGitBranch ?: SharedLibrary.getVersion(env) ?: "master"
     GitRepo appGitRepo = params.getAppGitRepo()
 
     if (!appGitRepo) {


### PR DESCRIPTION
Allow to do 
```
        InitializeWorkdirIn initializeWorkdirIn = new InitializeWorkdirIn()
        initializeWorkdirIn.configGitBranch = 'some-branch'
        AppConfig conf = initializeWorkdir.stage(initializeWorkdirIn)
```
to use a specific CD config branch